### PR TITLE
more informational changes to e2e logging

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -40,11 +40,11 @@ function exit-trap {
     local component
     for component in ${components}; do
       local podname=$(kubectl get po --namespace=deis | awk '{print $1}' | grep "${component}")
-      kubectl describe po "${podname}" --namespace=deis &> "${DEIS_LOG_DIR}/${component}-describe.log"
-      log-info "Retrieving logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs.log"
-      kubectl logs "${podname}" --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs.log"
-      log-info "Retrieving previous instance logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs.log"
-      kubectl logs "${podname}" -p --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs.log"
+      kubectl describe po "${podname}" --namespace=deis &> "${DEIS_LOG_DIR}/${component}.describe"
+      log-info "Retrieving logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}.log"
+      kubectl logs "${podname}" --namespace=deis >> "${DEIS_LOG_DIR}/${component}.log"
+      log-info "Retrieving previous instance logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}.log"
+      kubectl logs "${podname}" -p --namespace=deis >> "${DEIS_LOG_DIR}/${component}.log"
     done
   fi
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -67,11 +67,11 @@ function log-lifecycle {
 }
 
 function log-info {
-  rerun_log "--> ${@}"
+  rerun_log "-----> ${@}"
 }
 
 function log-warn {
-  rerun_log warn "--> ${@}"
+  rerun_log warn "-----> ${@}"
 }
 
 function save-environment {

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -43,8 +43,9 @@ function exit-trap {
     for component in ${components}; do
       kubectl describe po -l app=${component} --namespace=deis &> "${DEIS_LOG_DIR}/${component}-describe-${timestamp}.log"
       local podname=$(kubectl get po --namespace=deis | awk '{print $1}' | grep "${component}")
-      kubectl logs "${podname}" --namespace=deis > "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
-      echo "----------------------------" >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
+      log-info "Retrieving logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
+      kubectl logs "${podname}" --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
+      log-info "Retrieving previous instance logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
       kubectl logs "${podname}" -p --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
     done
   fi

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -33,20 +33,18 @@ function exit-trap {
 
   log-info "Retrieving information about the kubernetes/deis cluster before exiting..."
 
-  local timestamp="$(date +%Y-%m-%d+%H:%M:%S)"
-
   if command -v kubectl &> /dev/null; then
-    kubectl get po,rc,svc -a --namespace=deis &> "${DEIS_LOG_DIR}/statuses-${timestamp}.log"
+    kubectl get po,rc,svc -a --namespace=deis &> "${DEIS_LOG_DIR}/statuses.log"
 
     local components="deis-builder deis-database deis-minio deis-registry deis-router deis-controller"
     local component
     for component in ${components}; do
-      kubectl describe po -l app=${component} --namespace=deis &> "${DEIS_LOG_DIR}/${component}-describe-${timestamp}.log"
       local podname=$(kubectl get po --namespace=deis | awk '{print $1}' | grep "${component}")
-      log-info "Retrieving logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
-      kubectl logs "${podname}" --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
-      log-info "Retrieving previous instance logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
-      kubectl logs "${podname}" -p --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs-${timestamp}.log"
+      kubectl describe po "${podname}" --namespace=deis &> "${DEIS_LOG_DIR}/${component}-describe.log"
+      log-info "Retrieving logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs.log"
+      kubectl logs "${podname}" --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs.log"
+      log-info "Retrieving previous instance logs from ${podname}" >> "${DEIS_LOG_DIR}/${component}-logs.log"
+      kubectl logs "${podname}" -p --namespace=deis >> "${DEIS_LOG_DIR}/${component}-logs.log"
     done
   fi
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -71,7 +71,7 @@ function log-info {
 }
 
 function log-warn {
-  rerun_log warn "-----> ${@}"
+  rerun_log warn " !!!   ${@}"
 }
 
 function save-environment {

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -31,7 +31,7 @@ source ${RERUN_MODULE_DIR}/lib/deis.sh
 function exit-trap {
   set +e
 
-  log-warn "Retrieving information about the kubernetes/deis cluster before exiting..."
+  log-info "Retrieving information about the kubernetes/deis cluster before exiting..."
 
   local timestamp="$(date +%Y-%m-%d+%H:%M:%S)"
 


### PR DESCRIPTION
This PR:

 - changes the format of `log-warn` different than `log-info`
 - shows more information about the logging process in the component logs
 - removes the timestamp since all logs are written to their corresponding build ID directory