### PR TITLE
chore(gke): Update node size to n1-standard-4 and move to a 4 node cluster

### DIFF
--- a/lib/gke.sh
+++ b/lib/gke.sh
@@ -27,7 +27,7 @@ function gke::config {
 
 function gke::create-cluster {
   log-lifecycle "Creating cluster ${K8S_CLUSTER_NAME}"
-  gcloud -q container clusters create "${K8S_CLUSTER_NAME}" -m n1-standard-2
+  gcloud -q container clusters create "${K8S_CLUSTER_NAME}" -m n1-standard-4 --num-nodes 5
   gcloud -q config set container/cluster "${K8S_CLUSTER_NAME}"
   gcloud -q container clusters get-credentials "${K8S_CLUSTER_NAME}"
 }


### PR DESCRIPTION
This is to help facilitate running the workflow e2e tests in parallel