### PR TITLE
fix(commands/test/script): run helm generate on the e2e chart

### DIFF
--- a/commands/test/script
+++ b/commands/test/script
@@ -52,6 +52,7 @@ trap "retrieve-deis-info" EXIT
 WORKFLOW_E2E_CONTAINER="tests"
 mkdir -p "${HELM_HOME}/cache/deis/${WORKFLOW_E2E_CHART}"
 helm fetch "deis/${WORKFLOW_E2E_CHART}"
+helm generate "${WORKFLOW_E2E_CHART}"
 helm uninstall -n deis -y "${WORKFLOW_E2E_CHART}"
 helm install "${WORKFLOW_E2E_CHART}"
 


### PR DESCRIPTION
cc/ @sgoings @vdice 

The workflow-e2e chart will now be parameterized, so `helm generate` will need to be run on it. See https://github.com/deis/charts/pull/224