### PR TITLE
feat(bumpver/install/test): ability to specify remote helm repo/branch/name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ associated helm commands such as:
   helm install ...
   ```
 
+If there is a need to use a remote helm repo and/or branch other than the default(s),
+you may export values for `HELM_REMOTE_REPO` and, optionally, `HELM_REMOTE_BRANCH`
+and `HELM_REMOTE_NAME`:
+
+```
+$ export HELM_REMOTE_REPO=https://github.com/my/remote/repo.git
+$ export HELM_REMOTE_BRANCH=my-branch
+$ export HELM_REMOTE_NAME=my-remote
+```
+
 ### test
 
 Run the e2e test suite for deis workflow.

--- a/commands/bumpver/script
+++ b/commands/bumpver/script
@@ -50,7 +50,7 @@ load-config
 helm doctor
 
 log-info "Adding deis helm repo..."
-helm repo add deis https://github.com/deis/charts.git || true
+helm repo add "${HELM_REMOTE_NAME}" "${HELM_REMOTE_REPO}" || true
 
 # log-info "INJECTING VERSIONS!"
 # log-info "-------------------"
@@ -67,4 +67,4 @@ helm repo add deis https://github.com/deis/charts.git || true
 # bumpver-if-set "${WORKFLOW_CHART}" "dockerbuilder" "${DOCKERBUILDER_SHA}"
 # bumpver-if-set "${WORKFLOW_E2E_CHART}" "workflow-e2e" "${WORKFLOW_E2E_SHA}"
 # log-info "-------------------"
-# rsync --exclude ".*/" -av . "${HELM_HOME}/cache/deis/" > /dev/null
+# rsync --exclude ".*/" -av . "${HELM_HOME}/cache/${HELM_REMOTE_NAME}/" > /dev/null

--- a/commands/install/script
+++ b/commands/install/script
@@ -51,16 +51,31 @@ load-config
 kubectl get events --all-namespaces -w > ${K8S_EVENT_LOG} 2>&1 &
 
 helm doctor
-log-info "Adding deis helm repo..."
-helm repo add deis https://github.com/deis/charts.git || true
+
+log-info "Removing helm repo ${HELM_REMOTE_NAME} if exists..."
+helm repo remove "${HELM_REMOTE_NAME}" || true
+
+log-info "Adding helm repo ${HELM_REMOTE_REPO} as ${HELM_REMOTE_NAME}..."
+helm repo add "${HELM_REMOTE_NAME}" "${HELM_REMOTE_REPO}" || true
+
+if [ "${HELM_REMOTE_BRANCH}" != "master" ]; then
+  log-info "Checking out ${HELM_REMOTE_BRANCH} branch..."
+  cd "${HELM_HOME}/cache/${HELM_REMOTE_NAME}"
+  git checkout "${HELM_REMOTE_BRANCH}"
+fi
+
 log-info "Update the charts!"
 helm up
-log-info "Fetching deis/${WORKFLOW_CHART}"
-helm fetch "deis/${WORKFLOW_CHART}"
+
+log-info "Fetching ${HELM_REMOTE_NAME}/${WORKFLOW_CHART}"
+helm fetch "${HELM_REMOTE_NAME}/${WORKFLOW_CHART}"
+
 log-info "Generate manifests from templates"
-helm generate -x manifests "${WORKFLOW_CHART}"
+helm generate -f -x manifests "${WORKFLOW_CHART}"
+
 log-info "Installing chart ${WORKFLOW_CHART}"
 helm install "${WORKFLOW_CHART}"
+
 log-info "Running kubectl describe pods and piping the output to ${DEIS_DESCRIBE}"
 kubectl describe ns,svc,pods,rc,daemonsets --namespace=deis > "${DEIS_DESCRIBE}"
 print-out-running-images || true

--- a/commands/test/script
+++ b/commands/test/script
@@ -50,9 +50,9 @@ load-config
 trap "retrieve-deis-info" EXIT
 
 WORKFLOW_E2E_CONTAINER="tests"
-mkdir -p "${HELM_HOME}/cache/deis/${WORKFLOW_E2E_CHART}"
-helm fetch "deis/${WORKFLOW_E2E_CHART}"
-helm generate "${WORKFLOW_E2E_CHART}"
+mkdir -p "${HELM_HOME}/cache/${HELM_REMOTE_NAME}/${WORKFLOW_E2E_CHART}"
+helm fetch "${HELM_REMOTE_NAME}/${WORKFLOW_E2E_CHART}"
+helm generate -f "${WORKFLOW_E2E_CHART}"
 helm uninstall -n deis -y "${WORKFLOW_E2E_CHART}"
 helm install "${WORKFLOW_E2E_CHART}"
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -3,16 +3,18 @@ ARCH="$(uname -m)"
 
 # helm configuration
 export HELM_ARTIFACT_REPO="${HELM_ARTIFACT_REPO:-helm}"
+export HELM_REMOTE_NAME="${HELM_REMOTE_NAME:-deis}"
+export HELM_REMOTE_REPO="${HELM_REMOTE_REPO:-https://github.com/deis/charts.git}"
+export HELM_REMOTE_BRANCH="${HELM_REMOTE_BRANCH:-master}"
 export WORKFLOW_CHART="${WORKFLOW_CHART:-workflow-dev}"
 export WORKFLOW_E2E_CHART="${WORKFLOW_E2E_CHART:-workflow-dev-e2e}"
 
-if [ -n ${JOB_NAME} ]; then
+if [ -n "${JOB_NAME}" ]; then
   export HELM_HOME="${HOME}/.helm/${JOB_NAME}/${BUILD_NUMBER}"
-  echo "Setting HELM_HOME to $HELM_HOME"
 else
   export HELM_HOME="${HOME}/.helm"
-  echo "Setting HELM_HOME to $HELM_HOME"
 fi
+echo "Setting HELM_HOME to ${HELM_HOME}"
 
 # cluster defaults
 GOOGLE_SDK_DIR="${HOME}/google-cloud-sdk"


### PR DESCRIPTION
This will also help support our current release testing efforts.  That is, we can now export env vars related to release repos/branches before invoking ci, so that release charts not yet existing in `deis/charts.git` can be tested.  For instance:
```
export HELM_REMOTE_REPO=<git repo other than deis/charts.git>
export HELM_REMOTE_BRANCH=<git branch other than master>
WORKFLOW_CHART=workflow-<release> WORKFLOW_E2E_CHART=workflow-e2e-<release> ./ci.sh
```